### PR TITLE
Update multimap gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
     minitest (4.7.5)
     multi_json (1.8.2)
     multi_test (0.0.2)
-    multimap (1.1.2)
+    multimap (1.1.3)
     multipart-post (1.2.0)
     nest (1.1.2)
       redis


### PR DESCRIPTION
@mscoutermarsh 

The Gemfile.lock had the version set to 1.1.2, this version has
  since been [yanked](https://rubygems.org/gems/multimap/versions) from rubygems. This updates it to the current version, 1.1.3.

Installing was failing with locked version of yanked gem.
